### PR TITLE
Add CUDA debug and NVIDIA profiling support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "CUDA Debug: active file",
+            "type": "cuda-gdb",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/debug/${fileBasenameNoExtension}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "preLaunchTask": "build-debug: active file",
+            "cuda": {
+                "breakOnLaunch": true
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "files.associations": {
+        "*.cu": "cuda-cpp",
+        "*.cuh": "cuda-cpp"
+    },
+    "C_Cpp.default.compilerPath": "/usr/local/cuda/bin/nvcc",
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}/src",
+        "/usr/local/cuda/include"
+    ],
+    "C_Cpp.default.defines": [
+        "__CUDACC__"
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build-debug: active file",
+            "type": "shell",
+            "command": "make",
+            "args": ["debug", "${fileBasename}"],
+            "group": "build",
+            "presentation": {
+                "reveal": "always",
+                "panel": "shared",
+                "clear": true
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 3.18)
 project(CUDA_Project LANGUAGES CXX CUDA)
 
-# Set output directory for executables
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-# Enable CUDA support
 enable_language(CUDA)
+
+# Device-side debug info (-G) + host debug info (-g) when building Debug
+set(CMAKE_CUDA_FLAGS_DEBUG "-g -G")
 
 # Add the source file
 file(GLOB SOURCE_FILES src/*.cu)

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,30 @@
 BUILD_DIR = build
 
-.PHONY: configure clean clean-all build
+.PHONY: configure clean clean-all build debug profile ncu
 
 configure:
 	@poetry install
 
-# Absorb the .cu filename as a goal: make build <file.cu>
-ifeq ($(firstword $(MAKECMDGOALS)),build)
-  _BUILD_FILE := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
-  ifneq ($(_BUILD_FILE),)
-    _BUILD_TARGET := $(basename $(_BUILD_FILE))
-    $(eval $(_BUILD_FILE):;@true)
-  endif
+# Second word on the command line is always the optional <file.cu> argument.
+# Works for: make build hello_world.cu / make debug hello_world.cu / etc.
+_ARG    := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+_TARGET := $(basename $(_ARG))
+
+ifneq ($(_ARG),)
+  $(eval $(_ARG):;@true)
 endif
+
+# ── Release build ────────────────────────────────────────────────────────────
 
 build:
 	@mkdir -p $(BUILD_DIR)
 	@cmake -S . -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=Release -Wno-dev > /dev/null 2>&1
-	@if [ -n "$(_BUILD_TARGET)" ]; then \
-		echo "Building $(_BUILD_TARGET)..."; \
-		cmake --build $(BUILD_DIR) --target $(_BUILD_TARGET); \
+	@if [ -n "$(_TARGET)" ]; then \
+		echo "Building $(_TARGET)..."; \
+		cmake --build $(BUILD_DIR) --target $(_TARGET); \
 		echo ""; \
-		echo "=== $(_BUILD_TARGET) output ==="; \
-		$(BUILD_DIR)/$(_BUILD_TARGET) 2>&1 | tee $(BUILD_DIR)/$(_BUILD_TARGET)_output.txt; \
+		echo "=== $(_TARGET) output ==="; \
+		$(BUILD_DIR)/$(_TARGET) 2>&1 | tee $(BUILD_DIR)/$(_TARGET)_output.txt; \
 	else \
 		echo "Building all CUDA targets..."; \
 		cmake --build $(BUILD_DIR); \
@@ -34,6 +36,59 @@ build:
 			echo ""; \
 		done; \
 	fi
+
+# ── Debug build (cuda-gdb / breakpoints) ─────────────────────────────────────
+# Binaries land in build/debug/ to stay separate from the release build.
+# Use with: make debug hello_world.cu
+
+debug:
+	@mkdir -p $(BUILD_DIR)/debug
+	@cmake -S . -B $(BUILD_DIR)/debug -DCMAKE_BUILD_TYPE=Debug -Wno-dev > /dev/null 2>&1
+	@if [ -n "$(_TARGET)" ]; then \
+		echo "Building $(_TARGET) (debug)..."; \
+		cmake --build $(BUILD_DIR)/debug --target $(_TARGET); \
+		echo "Debug binary: $(BUILD_DIR)/debug/$(_TARGET)"; \
+	else \
+		echo "Building all CUDA targets (debug)..."; \
+		cmake --build $(BUILD_DIR)/debug; \
+		echo "Debug binaries in: $(BUILD_DIR)/debug/"; \
+	fi
+
+PROFILES_DIR = $(BUILD_DIR)/profiles
+
+# ── Nsight Systems — timeline / system-level profile ─────────────────────────
+# Usage: make profile hello_world.cu
+# Output: build/profiles/<target>_nsys.nsys-rep  (open in Nsight Systems GUI)
+
+profile:
+	@[ -n "$(_TARGET)" ] || (echo "Usage: make profile <file.cu>"; exit 1)
+	@[ -f "$(BUILD_DIR)/$(_TARGET)" ] || (echo "Binary not found — run: make build $(_ARG)"; exit 1)
+	@mkdir -p $(PROFILES_DIR)
+	@echo "Profiling $(_TARGET) with Nsight Systems..."
+	@nsys profile \
+		--output=$(PROFILES_DIR)/$(_TARGET)_nsys \
+		--stats=true \
+		--force-overwrite=true \
+		$(BUILD_DIR)/$(_TARGET)
+	@echo "Report saved: $(PROFILES_DIR)/$(_TARGET)_nsys.nsys-rep"
+
+# ── Nsight Compute — kernel-level metrics ────────────────────────────────────
+# Usage: make ncu hello_world.cu
+# Output: build/profiles/<target>_ncu.ncu-rep  (open in Nsight Compute GUI)
+
+ncu:
+	@[ -n "$(_TARGET)" ] || (echo "Usage: make ncu <file.cu>"; exit 1)
+	@[ -f "$(BUILD_DIR)/$(_TARGET)" ] || (echo "Binary not found — run: make build $(_ARG)"; exit 1)
+	@mkdir -p $(PROFILES_DIR)
+	@echo "Analyzing $(_TARGET) with Nsight Compute..."
+	@ncu \
+		--set full \
+		--export $(PROFILES_DIR)/$(_TARGET)_ncu \
+		--force-overwrite \
+		$(BUILD_DIR)/$(_TARGET)
+	@echo "Report saved: $(PROFILES_DIR)/$(_TARGET)_ncu.ncu-rep"
+
+# ── Cleanup ───────────────────────────────────────────────────────────────────
 
 clean:
 	@rm -rf $(BUILD_DIR)


### PR DESCRIPTION
- CMakeLists: add -g -G device/host debug flags for Debug builds
- Makefile: refactor arg parsing; add debug, profile (nsys), ncu targets
- .vscode/launch.json: cuda-gdb config with breakOnLaunch for active file
- .vscode/tasks.json: pre-launch debug build task for active file
- .vscode/settings.json: CUDA file associations and nvcc include paths